### PR TITLE
Remove fibers dependency (fixes czbaker/meteor-request#2)

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,8 +1,5 @@
 {
   "dependencies": {
-    "fibers": {
-      "version": "1.0.1"
-    },
     "request": {
       "version": "2.40.0",
       "dependencies": {

--- a/package.js
+++ b/package.js
@@ -6,7 +6,6 @@ Package.describe({
 });
 
 Npm.depends({
-	"fibers": "1.0.1",
 	"request": "2.40.0"
 })
 


### PR DESCRIPTION
From my testing, depending on fibers is not necessary.  When you bundle it with your package, then you have to publish-for-arch for all supported meteor platforms or else cryptic errors will show up for users on those platforms.